### PR TITLE
Bugfixing and changes based on SIK-549

### DIFF
--- a/src/scripts/search/controllers/searchAdvancedController.js
+++ b/src/scripts/search/controllers/searchAdvancedController.js
@@ -39,7 +39,6 @@
             })
 
             $scope.$on('deleteOperation', function () {
-                console.log('false');
                 $scope.editor = false;
             })
 
@@ -63,19 +62,14 @@
             $scope.QueryAPI = function () {
                 if (!$scope.editor) {
                     SearchAdvancedService.BuildQuery($scope.selectedLayer);
-                    //TODO: API call with query or operations as args ?
                     var query = SearchAdvancedService.TranslateOperations($scope.operations);
                     var result = SearchAdvancedService.ExecuteQuery($scope.selectedLayer, query);
-                    console.log(result);
                 } else {
-                    //TODO: API call with query
                     var rawQueryResult = SearchAdvancedService.MakeNewRawQuery($scope.query);
                     if (rawQueryResult.layer != null) {
                         var result = SearchAdvancedService.ExecuteQuery(rawQueryResult.layer, rawQueryResult.query);
                     }
-                    console.log(result);
                 }
-                console.log("API Call : " + $scope.query); //TODO: remove this testing placeholder
                 
                 UIService.OpenLeftSide();
                 $modalInstance.$close();

--- a/src/scripts/search/controllers/searchOperationsController.js
+++ b/src/scripts/search/controllers/searchOperationsController.js
@@ -27,12 +27,15 @@
                 $scope.autoCompleteActive = false;
                 $scope.changeoperation();
                 
-                if (document.activeElement != document.getElementById('input_waarde')){
+                const op = $scope.operations[index];
+
+                if (document.activeElement != document.getElementById('input_waarde') && op.attribute != null){
                     var prom = ExecuteEmptyAutoCompleteQuery();
 
                     prom.then(function(arg) {
-                        if(arg && arg.featureCollection.features != null) {
-                            $scope.autoComplete[$scope.index].collection = arg.featureCollection.features.filter(onlyUnique);
+                        if(arg && arg.error == undefined && arg.featureCollection.features != null) {
+                            const result = GetAutoCompleteValue(arg.featureCollection.features);
+                            $scope.autoComplete[$scope.index].collection = result.filter(onlyUnique);
                         } else {
                             $scope.autoComplete[$scope.index].collection = [];
                         }
@@ -115,7 +118,10 @@
             $scope.changeoperation = function() {
                 $scope.$emit('addedOperation', $scope.operations);
                 setTimeout(function() {
-                    initializeTypeahead();
+                    var op = $scope.operations[$scope.index];
+                    if (op.attribute != null) {
+                        initializeTypeahead();
+                    }
                 }, 100);
             };
 
@@ -140,7 +146,7 @@
                     var queryParams = SearchAdvancedService.BuildAutoCompleteQuery(query, $scope.index);
                     MapService.startAutoComplete(queryParams.layer, queryParams.attribute, queryParams.query)
                         .then(function(arg) {
-                            if(arg && arg.featureCollection.features != null) {
+                            if(arg && arg.error == undefined && arg.featureCollection.features != null) {
                                 const result = GetAutoCompleteValue(arg.featureCollection.features);
                                 $scope.autoComplete[$scope.index].collection = result.filter(onlyUnique);
                             } else {

--- a/src/scripts/search/controllers/searchOperationsController.js
+++ b/src/scripts/search/controllers/searchOperationsController.js
@@ -32,7 +32,7 @@
 
                     prom.then(function(arg) {
                         if(arg && arg.featureCollection.features != null) {
-                            $scope.autoComplete[$scope.index].collection = arg.featureCollection.features;
+                            $scope.autoComplete[$scope.index].collection = arg.featureCollection.features.filter(onlyUnique);
                         } else {
                             $scope.autoComplete[$scope.index].collection = [];
                         }
@@ -141,7 +141,8 @@
                     MapService.startAutoComplete(queryParams.layer, queryParams.attribute, queryParams.query)
                         .then(function(arg) {
                             if(arg && arg.featureCollection.features != null) {
-                                $scope.autoComplete[$scope.index].collection = GetAutoCompleteValue(arg.featureCollection.features);
+                                const result = GetAutoCompleteValue(arg.featureCollection.features);
+                                $scope.autoComplete[$scope.index].collection = result.filter(onlyUnique);
                             } else {
                                 $scope.autoComplete[$scope.index].collection = [];
                             }
@@ -150,6 +151,10 @@
                 } else {
                     syncResults($scope.autoComplete[$scope.index].collection);
                 }
+            }
+
+            function onlyUnique(value, index, self) { 
+                return self.indexOf(value) === index;
             }
 
             var GetAutoCompleteValue = function(collection) {

--- a/src/scripts/search/services/searchAdvancedService.js
+++ b/src/scripts/search/services/searchAdvancedService.js
@@ -156,7 +156,7 @@
                 if (val == "") {
                     query = op.attribute.name + " is not null";
                 } else {
-                    query = op.attribute.name + " like '" + val + "%'";
+                    query = op.attribute.name + " like '%" + val + "%'";
                 }
                 return {    layer: $rootScope.selectedLayer,
                             attribute: op.attribute,

--- a/src/scripts/search/services/searchAdvancedService.js
+++ b/src/scripts/search/services/searchAdvancedService.js
@@ -79,7 +79,6 @@
                     query += ')';
                 }
             });
-            console.log(query);
             return query;
         }
 
@@ -122,8 +121,6 @@
         }
 
         _service.IsLayerField = function(currentLayer, fieldname) {
-            console.log(currentLayer);
-            console.log(fieldname);
             var isLayerField = false;
             currentLayer.fields.forEach(field => {
                 if (field.name == fieldname) {


### PR DESCRIPTION
fix: Now only shows unique values in autocomplete. No more lists with the same values over and over.
fix: No longer throws error when changing layer in Query Builder.
change: autocomplete will now act as a 'like' query. Previously when searching "Meunier" the "Constantin Meunierplein" would not be found. This is now resolved.
